### PR TITLE
Add systemd variable to cause restart when external config changed.

### DIFF
--- a/roles/systemd-docker-service/README.md
+++ b/roles/systemd-docker-service/README.md
@@ -4,28 +4,29 @@ Renders a systemd unit file that runs an application within a docker container.
 
 ## Variables
 
-| Name                              | Mandatory | Description                                                           |
-| --------------------------------- | --------- | --------------------------------------------------------------------- |
-| systemd_service_name              | yes       | The name of the systemd service                                       |
-| systemd_docker_image_name         | yes       | The name of the docker image to run                                   |
-| systemd_docker_image_tag          | yes       | The tag of the docker image to run                                    |
-| systemd_service_environment       |           | Environment variables to pass through to the docker container         |
-| systemd_docker_network            |           | The docker network to use                                             |
-| systemd_docker_command            |           | The command to tun the docker container with                          |
-| systemd_docker_volumes            |           | Volumes to mount into the docker container                            |
-| systemd_docker_cap_add            |           | Additional capabilities of the docker container                       |
-| systemd_docker_ports              |           | Ports of the docker container to expose                               |
-| systemd_docker_host_to_ip_mapping |           | Adds additional hosts to the docker container                         |
-| systemd_docker_cpus               |           | The number of CPUs for the docker container to use                    |
-| systemd_docker_cpu_period         |           | The CPU time period for the docker container to use                   |
-| systemd_docker_cpu_quota          |           | The number of microseconds per period for the docker container to use |
-| systemd_docker_memory             |           | The maximum amount of memory for the docker container to use          |
-| systemd_service_restart_sec       |           | The number of seconds to wait before restarting the systemd service   |
-| systemd_service_timeout_start_sec |           | The number of seconds to wait before starting the systemd service     |
-| systemd_service_timeout_stop_sec  |           | The number of seconds to wait for the systemd service to stop         |
-| systemd_service_after             |           | The systemd unit after dependencies                                   |
-| systemd_service_requires          |           | The systemd unit requires dependencies                                |
-| systemd_start                     |           | Starts the systemd service after rendering the template               |
+| Name                              | Mandatory | Description                                                                           |
+| --------------------------------- | --------- | ------------------------------------------------------------------------------------- |
+| systemd_service_name              | yes       | The name of the systemd service                                                       |
+| systemd_docker_image_name         | yes       | The name of the docker image to run                                                   |
+| systemd_docker_image_tag          | yes       | The tag of the docker image to run                                                    |
+| systemd_service_environment       |           | Environment variables to pass through to the docker container                         |
+| systemd_docker_network            |           | The docker network to use                                                             |
+| systemd_docker_command            |           | The command to tun the docker container with                                          |
+| systemd_docker_volumes            |           | Volumes to mount into the docker container                                            |
+| systemd_docker_cap_add            |           | Additional capabilities of the docker container                                       |
+| systemd_docker_ports              |           | Ports of the docker container to expose                                               |
+| systemd_docker_host_to_ip_mapping |           | Adds additional hosts to the docker container                                         |
+| systemd_docker_cpus               |           | The number of CPUs for the docker container to use                                    |
+| systemd_docker_cpu_period         |           | The CPU time period for the docker container to use                                   |
+| systemd_docker_cpu_quota          |           | The number of microseconds per period for the docker container to use                 |
+| systemd_docker_memory             |           | The maximum amount of memory for the docker container to use                          |
+| systemd_service_restart_sec       |           | The number of seconds to wait before restarting the systemd service                   |
+| systemd_service_timeout_start_sec |           | The number of seconds to wait before starting the systemd service                     |
+| systemd_service_timeout_stop_sec  |           | The number of seconds to wait for the systemd service to stop                         |
+| systemd_service_after             |           | The systemd unit after dependencies                                                   |
+| systemd_service_requires          |           | The systemd unit requires dependencies                                                |
+| systemd_start                     |           | Starts the systemd service after rendering the template                               |
+| systemd_external_config_changed   |           | Indicates that the systemd should be restarted because external configuration changed | 
 
 ## Examples
 

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 systemd_start: yes
+systemd_external_config_changed: no
 systemd_service_environment: {}
 systemd_docker_network:
 systemd_docker_command:

--- a/roles/systemd-docker-service/tasks/main.yml
+++ b/roles/systemd-docker-service/tasks/main.yml
@@ -18,7 +18,7 @@
     state: restarted
     enabled: yes
   when:
-    - result is changed
+    - result is changed or systemd_external_config_changed | bool
     - systemd_start | bool
 
 - name: ensure service is started


### PR DESCRIPTION
The systemd service only restarts if the service.j2 templates changes. However, there are often more configuration files provided from the caller of this role, which would require a restart of the systemd service. 

With the new variable `systemd_external_config_changed`, the caller can pass in a boolean value to enforce a systemd service restart.

Example:

```
- name: template haproxy config
  template:
    src: haproxy.j2
    dest: "{{ haproxy_host_dir_path }}/config/haproxy.cfg"
    owner: "root"
    group: "root"
    mode: "0750"
  register: result

- name: deploy haproxy service
  include_role:
    name: systemd-docker-service
  vars:
    systemd_service_name: haproxy
    systemd_docker_image_name: "{{ haproxy_image_name }}"
    systemd_external_config_changed: "{{ result is changed }}"
    ...
```