### PR TITLE
Add retry when attempting to start systemd service.

### DIFF
--- a/roles/systemd-docker-service/tasks/main.yml
+++ b/roles/systemd-docker-service/tasks/main.yml
@@ -20,6 +20,10 @@
   when:
     - result is changed or systemd_external_config_changed | bool
     - systemd_start | bool
+  register: start_result
+  until: start_result is success
+  retries: 2
+  delay: 10
 
 - name: ensure service is started
   systemd:


### PR DESCRIPTION
Seems like sometimes an error can occur here when Docker images can not be loaded fast enough.