### PR TITLE
Pre-pull docker image.

### DIFF
--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -13,3 +13,4 @@ systemd_service_timeout_start_sec: 10
 systemd_service_timeout_stop_sec: 10
 systemd_service_after: docker.service
 systemd_service_requires: docker.service
+systemd_docker_image_tag: latest

--- a/roles/systemd-docker-service/tasks/main.yml
+++ b/roles/systemd-docker-service/tasks/main.yml
@@ -12,6 +12,9 @@
   when:
     - result is changed
 
+- name: pre-pull docker image
+  command: docker pull {{ systemd_docker_image_name }}:{{ systemd_docker_image_tag }}
+
 - name: start service {{ systemd_service_name }}
   systemd:
     name: "{{ systemd_service_name }}"


### PR DESCRIPTION
We have seen that in some cases the docker image could not be pulled fast enough, such that systemd was aborting the pull and then starting from scratch. This produced an endless loop where the service did not come up. This could be a possible resolution to this issue.