### PR TITLE
Offer string value replacements in setup_yaml.

### DIFF
--- a/action_plugins/setup_yaml.py
+++ b/action_plugins/setup_yaml.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from traceback import format_exc
-from yaml import safe_load, safe_dump
+from yaml import safe_load
 
 from ansible.module_utils.urls import open_url
 from ansible.plugins.action import ActionBase

--- a/library/setup_yaml.py
+++ b/library/setup_yaml.py
@@ -41,6 +41,11 @@ options:
             - Can be used to disable recursive resolution of other files. This can be useful in certain situations.
         required: false
         default: true
+    replace:
+        description:
+            - A list of replacements that can be used for recursively replacing string values for given keys in
+              the remote file content.
+        required: false
 author:
     - metal-stack
 notes:


### PR DESCRIPTION
This feature allows us to to modify the registry location in our release vector YAML.