### PR TITLE
Don't "require" docker.service and remove pre-pull from systemd service.

### DIFF
--- a/roles/systemd-docker-service/README.md
+++ b/roles/systemd-docker-service/README.md
@@ -24,9 +24,9 @@ Renders a systemd unit file that runs an application within a docker container.
 | systemd_service_timeout_start_sec |           | The number of seconds to wait before starting the systemd service                     |
 | systemd_service_timeout_stop_sec  |           | The number of seconds to wait for the systemd service to stop                         |
 | systemd_service_after             |           | The systemd unit after dependencies                                                   |
-| systemd_service_requires          |           | The systemd unit requires dependencies                                                |
+| systemd_service_wants             |           | The systemd unit wants dependencies                                                   | 
 | systemd_start                     |           | Starts the systemd service after rendering the template                               |
-| systemd_external_config_changed   |           | Indicates that the systemd should be restarted because external configuration changed | 
+| systemd_external_config_changed   |           | Indicates that the systemd should be restarted because external configuration changed |
 
 ## Examples
 

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -12,5 +12,5 @@ systemd_service_restart_sec: 10
 systemd_service_timeout_start_sec: 10
 systemd_service_timeout_stop_sec: 10
 systemd_service_after: docker.service
-systemd_service_requires: docker.service
+systemd_service_wants: docker.service
 systemd_docker_image_tag: latest

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -1,10 +1,9 @@
 [Unit]
 Description={{ systemd_service_name }} {{ systemd_docker_image_tag }}
 After={{ systemd_service_after }}
-Requires={{ systemd_service_requires }}
+Wants={{ systemd_service_wants }}
 
 [Service]
-ExecStartPre=-/usr/bin/docker pull {{ systemd_docker_image_name }}:{{ systemd_docker_image_tag }}
 ExecStartPre=-/usr/bin/docker rm --force --volumes %n
 ExecStart=/usr/bin/docker run --name=%n \
 {% for key, value in systemd_service_environment.items() %}


### PR DESCRIPTION
The apt daily update sometimes stop the docker daemon, which causes all services that "require" docker to stop as well. We will then end up with exited, inactive services that won't be restarted anymore.

Also, we pre-pull images in the pre start hook, which is not so great. We have an own task for pre-pulling the image in the role, which does this task without the problem of interrupting the download if it takes too long to execute.