### PR TITLE
feat: max log size and files

### DIFF
--- a/roles/systemd-docker-service/README.md
+++ b/roles/systemd-docker-service/README.md
@@ -22,6 +22,8 @@ Renders a systemd unit file that runs an application within a docker container.
 | systemd_docker_cpu_quota          |           | The number of microseconds per period for the docker container to use                 |
 | systemd_docker_memory             |           | The maximum amount of memory for the docker container to use                          |
 | systemd_docker_log_driver         |           | The log driver to use for the container instead of the system default                 |
+| systemd_docker_log_opt_max_file   |           | The maximum amount of log files if applicable                                         |
+| systemd_docker_log_opt_max_size   |           | The maximum log file size if applicable                                               |
 | systemd_service_restart_sec       |           | The number of seconds to wait before restarting the systemd service                   |
 | systemd_service_timeout_start_sec |           | The number of seconds to wait before starting the systemd service                     |
 | systemd_service_timeout_stop_sec  |           | The number of seconds to wait for the systemd service to stop                         |

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -17,5 +17,5 @@ systemd_service_bindsto:
 systemd_service_wants: docker.service
 systemd_docker_image_tag: latest
 
-systemd_docker_log_opt_max_file: 2
-systemd_docker_log_opt_max_size: 10m
+systemd_docker_log_opt_max_file: 5
+systemd_docker_log_opt_max_size: 4m

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -17,5 +17,5 @@ systemd_service_bindsto:
 systemd_service_wants: docker.service
 systemd_docker_image_tag: latest
 
-systemd_docker_log_opt_max_file: "{{ '2' if systemd_docker_log_driver is not defined or systemd_docker_log_driver == 'json-file' else None }}"
-systemd_docker_log_opt_max_size: "{{ '10m' if systemd_docker_log_driver is not defined or systemd_docker_log_driver == 'json-file' else None }}"
+systemd_docker_log_opt_max_file: 2
+systemd_docker_log_opt_max_size: 10m

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -16,3 +16,6 @@ systemd_service_after: docker.service
 systemd_service_bindsto:
 systemd_service_wants: docker.service
 systemd_docker_image_tag: latest
+
+systemd_docker_log_opt_max_file: "{{ '2' if systemd_docker_log_driver is not defined or systemd_docker_log_driver == 'json-file' else None }}"
+systemd_docker_log_opt_max_size: "{{ '10m' if systemd_docker_log_driver is not defined or systemd_docker_log_driver == 'json-file' else None }}"

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -38,13 +38,13 @@ ExecStart=/usr/bin/docker run --name=%n \
 {% endif %}
 {% if systemd_docker_log_driver is defined %}
     --log-driver {{ systemd_docker_log_driver }} \
-{% if systemd_docker_log_driver is "json-file" %}
+{% endif %}
+{% if systemd_docker_log_driver is not defined or systemd_docker_log_driver == "json-file" %}
 {% if systemd_docker_log_opt_max_file is not defined %}
 {% set systemd_docker_log_opt_max_file "2" %}
 {% endif %}
 {% if systemd_docker_log_opt_max_size is not defined %}
 {% set systemd_docker_log_opt_max_size "10m" %}
-{% endif %}
 {% endif %}
 {% endif %}
 {% if systemd_docker_log_opt_max_file is defined %}

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -38,6 +38,20 @@ ExecStart=/usr/bin/docker run --name=%n \
 {% endif %}
 {% if systemd_docker_log_driver is defined %}
     --log-driver {{ systemd_docker_log_driver }} \
+{% if systemd_docker_log_driver is "json-file" %}
+{% if systemd_docker_log_opt_max_file is not defined %}
+{% set systemd_docker_log_opt_max_file "2" %}
+{% endif %}
+{% if systemd_docker_log_opt_max_size is not defined %}
+{% set systemd_docker_log_opt_max_size "10m" %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% if systemd_docker_log_opt_max_file is defined %}
+    --log-opt max-file={{ systemd_docker_log_opt_max_file }} \
+{% endif %}
+{% if systemd_docker_log_opt_max_size is defined %}
+    --log-opt max-size={{ systemd_docker_log_opt_max_size }} \
 {% endif %}
 {% if systemd_docker_network %}
     --network {{ systemd_docker_network }} \

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -39,10 +39,8 @@ ExecStart=/usr/bin/docker run --name=%n \
 {% if systemd_docker_log_driver is defined %}
     --log-driver {{ systemd_docker_log_driver }} \
 {% endif %}
-{% if systemd_docker_log_opt_max_file is defined %}
+{% if systemd_docker_log_driver is defined and systemd_docker_log_driver in ['local', 'json-file'] %}
     --log-opt max-file={{ systemd_docker_log_opt_max_file }} \
-{% endif %}
-{% if systemd_docker_log_opt_max_size is defined %}
     --log-opt max-size={{ systemd_docker_log_opt_max_size }} \
 {% endif %}
 {% if systemd_docker_network %}

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -39,14 +39,6 @@ ExecStart=/usr/bin/docker run --name=%n \
 {% if systemd_docker_log_driver is defined %}
     --log-driver {{ systemd_docker_log_driver }} \
 {% endif %}
-{% if systemd_docker_log_driver is not defined or systemd_docker_log_driver == "json-file" %}
-{% if systemd_docker_log_opt_max_file is not defined %}
-{% set systemd_docker_log_opt_max_file "2" %}
-{% endif %}
-{% if systemd_docker_log_opt_max_size is not defined %}
-{% set systemd_docker_log_opt_max_size "10m" %}
-{% endif %}
-{% endif %}
 {% if systemd_docker_log_opt_max_file is defined %}
     --log-opt max-file={{ systemd_docker_log_opt_max_file }} \
 {% endif %}


### PR DESCRIPTION
Introduces new parameters to allow configuring the log size and files of docker https://github.com/metal-stack/metal-roles/pull/290
closes metal-stack/metal-roles#285 (cc @iljarotar )

- allows explicitly setting the logger max file and size for docker
- the default logger for docker is `json-file`
- if it is set to json-file or is not set at all, we default max file and size