### PR TITLE
Add wantedby var to systemd service

### DIFF
--- a/roles/systemd-docker-service/README.md
+++ b/roles/systemd-docker-service/README.md
@@ -29,6 +29,7 @@ Renders a systemd unit file that runs an application within a docker container.
 | systemd_service_timeout_stop_sec  |           | The number of seconds to wait for the systemd service to stop                         |
 | systemd_service_after             |           | The systemd unit after dependencies                                                   |
 | systemd_service_bindsto           |           | The systemd unit bindsto dependencies                                                 |
+| systemd_service_wantedby          |           | The systemd install wantedby dependencies                                             |
 | systemd_service_wants             |           | The systemd unit wants dependencies                                                   |
 | systemd_start                     |           | Starts the systemd service after rendering the template                               |
 | systemd_external_config_changed   |           | Indicates that the systemd should be restarted because external configuration changed |

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -14,6 +14,7 @@ systemd_service_timeout_start_sec: 10
 systemd_service_timeout_stop_sec: 10
 systemd_service_after: docker.service
 systemd_service_bindsto:
+systemd_service_wantedby: multi-user.target
 systemd_service_wants: docker.service
 systemd_docker_image_tag: latest
 

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -60,4 +60,4 @@ TimeoutStartSec={{ systemd_service_timeout_start_sec }}s
 TimeoutStopSec={{ systemd_service_timeout_stop_sec }}s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy={{ systemd_service_wantedby }}


### PR DESCRIPTION
## Description

This will enable automatic restart of services in SONiC when doing a `config reload`, e.g. for metal-core, by specifying `systemd_service_wantedby: sonic.target`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
