### PR TITLE
Actually run tests in CI and provide common Gardener Operator modules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,10 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: metalstack/metal-deployment-base:v0.0.5
+    container: metalstack/metal-deployment-base:latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Test
-      run: |
-        pip install nose coverage mock
-        nosetests
+      - uses: actions/checkout@v4
+      - name: Test
+        run: |
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .idea/
 venv/
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test
+test:
+	python3 -m pip install mock
+	./test.sh
+
+.PHONY: test-local
+test-local:
+	docker pull metalstack/metal-deployment-base:latest
+	docker run --rm -it -v $(PWD):/work -w /work metalstack/metal-deployment-base:latest make test

--- a/action_plugins/setup_yaml.py
+++ b/action_plugins/setup_yaml.py
@@ -150,8 +150,8 @@ class ActionModule(ActionBase):
                 value = self.resolve_path(f, path)
             except KeyError as e:
                 display.warning(
-                    """error reading variable from file, variable %s not found in path: %s 
-                    
+                    """error reading variable from file, variable %s not found in path: %s
+
                     (is the mapping appropriate for %s?)""" % (
                         to_native(e), path, url))
                 continue

--- a/action_plugins/virtual_garden_kubeconfig.py
+++ b/action_plugins/virtual_garden_kubeconfig.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from yaml import safe_load
+import base64
+from datetime import datetime, timedelta, timezone
+
+from ansible.plugins.action import ActionBase
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import PY3
+
+from kubernetes import client, config, dynamic
+from kubernetes.client.rest import ApiException
+
+HAS_JWT = True
+try:
+    import jwt # type: ignore[import]
+except ImportError as ex:
+    HAS_JWT = False
+
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+
+    display = Display()
+
+
+def b64decode(source):
+    content = base64.b64decode(source)
+    if PY3:
+        content = content.decode('utf-8')
+    return content
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        super(ActionModule, self).run(tmp, task_vars)
+        module_args = self._task.args.copy()
+        result = dict()
+
+        kubeconfig = module_args.get('kubeconfig', None)
+        garden_name = module_args.get('garden_name', 'local')
+        token_secret_name = module_args.get('token_secret_name', 'shoot-access-virtual-garden')
+        port = module_args.get('port', None)
+        refresh_minutes = module_args.get('refresh_minutes', 30)
+
+        # check token if already created and not expiring
+        already_present = task_vars.get("ansible_facts", {}).get('virtual_garden_kubeconfig', None)
+        expires_at = task_vars.get("ansible_facts", {}).get('virtual_garden_kubeconfig_expires_at', None)
+
+        if already_present and expires_at:
+            expires_in = datetime.fromtimestamp(expires_at, timezone.utc) - datetime.now(timezone.utc)
+            display.vvv("virtual garden kubeconfig expires in " + to_native(expires_in))
+            if expires_in > timedelta(minutes=refresh_minutes):
+                result["skipped"] = True
+                return result
+
+        try:
+            if kubeconfig:
+                if isinstance(kubeconfig, str) or kubeconfig is None:
+                    api_client = config.new_client_from_config(config_file=kubeconfig)
+                elif isinstance(kubeconfig, dict):
+                    api_client = config.new_client_from_config_dict(config_dict=kubeconfig)
+                else:
+                    result["failed"] = True
+                    result["msg"] = "error while reading kubeconfig parameter: a string or dict expected, but got %s instead" % type(kubeconfig)
+                    return result
+            else:
+                api_client = config.new_client_from_config()
+        except Exception as e:
+            result["failed"] = True
+            result["msg"] = "unable to create kubernetes client: " + to_native(e)
+            return result
+
+        token_secret = client.CoreV1Api(api_client).read_namespaced_secret(name=token_secret_name, namespace='garden')
+        if not token_secret.data:
+            result["failed"] = True
+            result["msg"] = "token secret shoot-access-virtual-garden does not contain data (yet?)"
+            return result
+
+        token = b64decode(token_secret.data.get('token'))
+        expires_at = None
+
+        if HAS_JWT:
+            claims = jwt.decode(
+                token,
+                "",
+                options={"require": ["exp"], "verify_exp": False, "verify_signature": False},
+                algorithms=["RS256"],
+            )
+
+            expires_at = claims['exp']
+
+        garden = dynamic.DynamicClient(client=api_client).resources.get(api_version='operator.gardener.cloud/v1alpha1', kind='Garden').get(name=garden_name)
+        server = 'api.' + garden.spec.virtualCluster.dns.domains[0].name
+
+        if port is None:
+            port = 443 # default port for exposal is 443
+
+            try:
+                # assume mini-lab in case the virtual garden was exposed through ingress-nginx
+                client.NetworkingV1Api(api_client).read_namespaced_ingress(name='apiserver-ingress', namespace='virtual-garden-istio-ingress')
+                port = 4443
+            except ApiException as e:
+                if e.status == 404:
+                    pass
+                else:
+                    result["failed"] = True
+                    result["msg"] = "error determining port for access kubeconfig: " + to_native(e)
+                    return result
+
+        generic_kubeconfig_secrets = client.CoreV1Api(api_client).list_namespaced_secret(namespace='garden', label_selector='managed-by=secrets-manager,manager-identity=gardener-operator,name=generic-token-kubeconfig')
+
+        generic_kubeconfig_secret = self._get_latest_secret(generic_kubeconfig_secrets)
+        if not generic_kubeconfig_secret:
+            result["failed"] = True
+            result["msg"] = "no latest generic-token-kubeconfig secret found"
+            return result
+
+        generic_kubeconfig = safe_load(b64decode(generic_kubeconfig_secret.data.get("kubeconfig"))).get("clusters")[0].get("cluster")
+
+        virtual_garden_kubeconfig = {
+            "apiVersion": "v1",
+            "kind": "Config",
+            "clusters": [
+                {
+                    "name": "default-cluster",
+                    "cluster": {
+                        "certificate-authority-data": generic_kubeconfig.get("certificate-authority-data"),
+                        "server": "https://" + server + ":" + str(port),
+                    }
+                }
+            ],
+            "current-context": "default-context",
+            "contexts": [
+                {
+                    "name": "default-context",
+                    "context": {
+                        "cluster": "default-cluster",
+                        "user": "default-user",
+                    }
+                }
+            ],
+            "users": [
+                {
+                    "name": "default-user",
+                    "user": {
+                        "token": safe_load(token),
+                    }
+                }
+            ],
+        }
+
+        result['virtual_garden_kubeconfig'] = virtual_garden_kubeconfig
+        if expires_at:
+            result['virtual_garden_kubeconfig_expires_at'] = expires_at
+
+        return dict(ansible_facts=dict(result))
+
+
+    @staticmethod
+    def _get_latest_secret(secrets):
+        latest = None
+        for secret in secrets.items:
+            issued_time = int(secret.metadata.labels.get('issued-at-time'))
+            if latest is None or int(secret.metadata.labels.get('issued-at-time')) < issued_time:
+                latest = secret
+        return latest

--- a/filter_plugins/gardener.py
+++ b/filter_plugins/gardener.py
@@ -8,6 +8,8 @@ import json
 
 from kubernetes import config, client
 
+from ansible.plugins.test.core import version_compare
+
 
 def shoot_admin_kubeconfig(kubeconfig, project_namespace, shoot_name, expiry_seconds=28800):
     data = yaml.safe_load(kubeconfig)
@@ -36,8 +38,88 @@ def shoot_admin_kubeconfig(kubeconfig, project_namespace, shoot_name, expiry_sec
     return base64.b64decode(json.loads(response.data)["status"]["kubeconfig"]).decode('utf-8')
 
 
+def machine_images_for_cloud_profile(image_list, cris=None, compatibilities=None):
+    images = dict()
+    for image in image_list:
+        if 'machine' not in image.get("features", list()):
+            continue
+
+        if image.get('omit_from_cloud_profile', False):
+            continue
+
+        image_id = image.get("id")
+        if image_id is None:
+            continue
+
+        parts = image_id.split("-")
+        name = "-".join(parts[:-1])
+
+        version = parts[-1]
+
+        version_parts = version.split(".")
+        # ubuntu-19.10.20200331
+        # major = version_parts[0]
+        minor = ".".join(version_parts[:2])
+
+        image_versions = images.get(name, set())
+        # Do not add the major version to the vector
+        # metal-api cannot match latest version if only major is given
+        # image_versions.add(major)
+        image_versions.add(minor)
+        image_versions.add(version)
+        images[name] = image_versions
+
+    result = list()
+    for name, value in images.items():
+        versions = list()
+        for v in sorted(list(value)):
+            version = dict(
+                version=v
+            )
+
+            if cris is not None and name in cris:
+                cri = cris[name].copy()
+                cri_config = cri.pop("cris", [])
+                cri_condition = cri.pop("when", None)
+
+                if cri_condition is None:
+                    version["cri"] = cri_config
+                else:
+                    if v in cri_condition.get("except", []):
+                        pass
+                    else:
+                        if version_compare(v, cri_condition["version"], cri_condition["operator"]):
+                            version["cri"] = cri_config
+
+            if compatibilities is not None and name in compatibilities:
+                compat = compatibilities[name].copy()
+
+                kubelet = compat.pop("kubelet")
+                condition = compat.pop("when", None)
+
+                if condition is None:
+                    version["kubeletVersionConstraint"] = kubelet
+                else:
+                    if v in condition.get("except", []):
+                        pass
+                    else:
+                        if version_compare(v, condition["version"], condition["operator"]):
+                            version["kubeletVersionConstraint"] = kubelet
+
+            versions.append(version)
+
+        image = dict(
+            name=name,
+            versions=versions,
+        )
+        result.append(image)
+
+    return result
+
+
 class FilterModule(object):
     def filters(self):
         return {
             'shoot_admin_kubeconfig': shoot_admin_kubeconfig,
+            'machine_images_for_cloud_profile': machine_images_for_cloud_profile,
         }

--- a/filter_plugins/gcp.py
+++ b/filter_plugins/gcp.py
@@ -1,0 +1,24 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+
+
+def extract_gcp_node_network(subnets, region):
+    for subnet in subnets:
+        subnetwork = subnet.get("subnetwork")
+        if not subnetwork:
+            continue
+
+        if region in subnetwork:
+            return subnet.get("ipCidrRange")
+
+    raise AnsibleFilterError("no node network found for region: %s" % region)
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'extract_gcp_node_network': extract_gcp_node_network,
+        }

--- a/library/patch_service_status_k8s.py
+++ b/library/patch_service_status_k8s.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import time
+import json
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run_module():
+    module_args = dict(
+        name=dict(type='str', required=True),
+        namespace=dict(type='str', required=True),
+        kubeconfig=dict(type='raw', no_log=True, required=False),
+        body=dict(type='dict', required=True)
+    )
+
+    result = dict(
+        changed=False,
+        result=''
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    kubeconfig = module.params.get('kubeconfig')
+
+    if isinstance(kubeconfig, str) or kubeconfig is None:
+        api_client = config.new_client_from_config(config_file=kubeconfig)
+    elif isinstance(kubeconfig, dict):
+        api_client = config.new_client_from_config_dict(config_dict=kubeconfig)
+    else:
+        module.fail_json(msg="Error while reading kubeconfig parameter - a string or dict expected, but got %s instead" % type(kubeconfig), **result)
+
+    api_instance = client.CoreV1Api(api_client)
+
+    name = module.params.get('name')
+    namespace = module.params.get('namespace')
+    body = module.params.get('body')
+
+    try:
+        api_response = api_instance.patch_namespaced_service_status(name, namespace, body)
+        result['changed'] = True
+        result['result'] = json.dumps(api_client.sanitize_for_serialization(api_response), sort_keys=True, indent=4)
+    except ApiException as e:
+        module.fail_json(msg="Exception when calling CoreV1Api->patch_namespaced_service_status: %s\n" % e, **result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/virtual_garden_kubeconfig.py
+++ b/library/virtual_garden_kubeconfig.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '0.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: virtual_garden_kubeconfig
+short_description: Retrieves a kubeconfig for accessing the virtual garden
+version_added: "2.10"
+description:
+    - This relies on the virtual garden access kubeconfig being deployed through a managed resource as described in the Gardener docs.
+    - Deploying a virtual garden like this can be achieved through the gardener operator.
+    - On repeated execution the module only creates a new kubeconfig in case the kubeconfig token is about to expire.
+options:
+    kubeconfig:
+        description:
+            - The kubeconfig used for finding the garden resource.
+            - Will be looked up from environment in case not defined.
+    port:
+        description:
+            - The port that the virtual garden is exposed on. the default is 443.
+            - If the port is not explicitly set the module will check if istio was exposed through an ingress resource, which is done for local setups (e.g. mini-lab). in this case it defaults to 4443.
+        required: false
+        default: 443
+    garden_name:
+        description:
+            - The name of the garden resource to get the access kubeconfig for.
+        required: false
+        default: local
+    token_secret_name:
+        description:
+            - The name the token secret for the virtual garden.
+        required: false
+        default: shoot-access-virtual-garden
+    refresh_minutes:
+        description:
+            - On repeated execution creates a new kubeconfig if the token expiration is smaller than refresh_minutes.
+        required: false
+        default: 30
+author:
+    - metal-stack
+notes:
+    - Relies on the kubernetes python client library.
+    - The refresh_minutes parameter does only have effect when pyjwt is installed.
+'''
+
+EXAMPLES = '''
+- name: Retrieve virtual garden kubeconfig
+  virtual_garden_kubeconfig:
+
+# The expected module return will be:
+# {"ansible_facts": {"gardener_virtual_garden_kubeconfig": "<a-kubeconfig>"}}
+'''

--- a/library/virtual_garden_kubeconfig.py
+++ b/library/virtual_garden_kubeconfig.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: virtual_garden_kubeconfig
 short_description: Retrieves a kubeconfig for accessing the virtual garden
-version_added: "2.10"
+version_added: "2.15"
 description:
     - This relies on the virtual garden access kubeconfig being deployed through a managed resource as described in the Gardener docs.
     - Deploying a virtual garden like this can be achieved through the gardener operator.
@@ -58,5 +58,5 @@ EXAMPLES = '''
   virtual_garden_kubeconfig:
 
 # The expected module return will be:
-# {"ansible_facts": {"gardener_virtual_garden_kubeconfig": "<a-kubeconfig>"}}
+# {"ansible_facts": {"virtual_garden_kubeconfig": "<a-kubeconfig>"}}
 '''

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+failed=0
+
+for file in $(find . -name test -type d -not -path "./venv/*"); do
+    echo "Running tests in $(dirname $file)"
+    python -m unittest discover -v -p '*_test.py' -s $(dirname $file) || failed=1
+done
+
+if [ $failed -eq 0 ]; then
+    echo "All tests passed."
+else
+    echo "One or more tests have failed."
+    exit 1
+fi

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,10 +1,4 @@
-import mock
 import os
-import json
-import unittest
-
-from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
 
 MODULES_PATH = os.path.join(os.path.dirname(os.path.abspath(os.path.dirname(__file__))), 'library')
 MODULE_UTILS_PATH = os.path.join(os.path.dirname(os.path.abspath(os.path.dirname(__file__))), 'module_utils')
@@ -12,52 +6,6 @@ FILTER_PLUGINS_PATH = os.path.join(os.path.dirname(os.path.abspath(os.path.dirna
 ACTION_PLUGINS_PATH = os.path.join(os.path.dirname(os.path.abspath(os.path.dirname(__file__))), 'action_plugins')
 
 
-def set_module_args(args):
-    """prepare arguments so that they will be picked up during module creation"""
-    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
-    basic._ANSIBLE_ARGS = to_bytes(args)
-
-
-class AnsibleExitJson(Exception):
-    """Exception class to be raised by module.exit_json and caught by the test case"""
-
-    def __init__(self, kwargs):
-        self.module_results = kwargs
-        super(AnsibleExitJson, self).__init__(kwargs)
-
-
-class AnsibleFailJson(Exception):
-    """Exception class to be raised by module.fail_json and caught by the test case"""
-
-    def __init__(self, kwargs):
-        self.module_results = kwargs
-        super(AnsibleFailJson, self).__init__(kwargs)
-
-
-def exit_json(_, **kwargs):
-    """function to patch over exit_json; package return data into an exception"""
-    if 'changed' not in kwargs:
-        kwargs['changed'] = False
-    raise AnsibleExitJson(kwargs)
-
-
-def fail_json(_, **kwargs):
-    """function to patch over fail_json; package return data into an exception"""
-    kwargs['failed'] = True
-    raise AnsibleFailJson(kwargs)
-
-
-class AnsibleCommon(unittest.TestCase):
-    def defaultSetUpTasks(self):
-        modules = {
-            'ansible.module_utils.metal': metal,
-        }
-        self.module_patcher = mock.patch.dict('sys.modules', modules)
-        self.module_patcher.start()
-        self.addCleanup(self.module_patcher.stop)
-
-        self.mock_module_helper = mock.patch.multiple(basic.AnsibleModule,
-                                                      exit_json=exit_json,
-                                                      fail_json=fail_json)
-        self.mock_module_helper.start()
-        self.addCleanup(self.mock_module_helper.stop)
+def read_mock_file(name):
+    with open(os.path.join(os.path.dirname(__file__), "mock", name), 'r') as f:
+        return f.read()

--- a/test/filter_plugins_test.py
+++ b/test/filter_plugins_test.py
@@ -1,34 +1,41 @@
 import sys
 import unittest
+import json
 
-from test import FILTER_PLUGINS_PATH
+from test import FILTER_PLUGINS_PATH, read_mock_file
 
 sys.path.insert(0, FILTER_PLUGINS_PATH)
-from common import parse_size
-from common import FilterModule
-
+import common
+import gcp
 
 class UtilsFilterTest(unittest.TestCase):
     def test_all_filters_present(self):
-        filters = FilterModule().filters()
+        for expected_filter in ["metal_lb_conf", "humanfriendly", "transpile_ignition_config"]:
+            self.assertIn(expected_filter, common.FilterModule().filters())
 
-        expected_filters = ["metal_lb_conf", "humanfriendly", "transpile_ignition_config"]
-
-        for expected_filter in expected_filters:
-            self.assertIn(expected_filter, filters)
-
+        for expected_filter in ["extract_gcp_node_network"]:
+            self.assertIn(expected_filter, gcp.FilterModule().filters())
 
 class HumanfriendlyTest(unittest.TestCase):
     def test_parsing_size(self):
-        actual = parse_size("1MB", binary=False)
+        actual = common.parse_size("1MB", binary=False)
 
         expected = 1000000
 
         self.assertEqual(expected, actual)
 
     def test_parsing_size_binary(self):
-        actual = parse_size("1KB", binary=True)
+        actual = common.parse_size("1KB", binary=True)
 
         expected = 1024
 
         self.assertEqual(expected, actual)
+
+
+class GCPTest(unittest.TestCase):
+    def test_extract_gcp_node_network(self):
+        subnets = json.loads(read_mock_file("gke_container_subnets.json"))
+
+        actual = gcp.extract_gcp_node_network(subnets, "europe-west3")
+
+        self.assertEqual("0.0.0.3/32", actual)

--- a/test/filter_plugins_test.py
+++ b/test/filter_plugins_test.py
@@ -1,12 +1,15 @@
 import sys
 import unittest
 import json
+import yaml
 
 from test import FILTER_PLUGINS_PATH, read_mock_file
 
 sys.path.insert(0, FILTER_PLUGINS_PATH)
 import common
 import gcp
+import gardener
+
 
 class UtilsFilterTest(unittest.TestCase):
     def test_all_filters_present(self):
@@ -39,3 +42,236 @@ class GCPTest(unittest.TestCase):
         actual = gcp.extract_gcp_node_network(subnets, "europe-west3")
 
         self.assertEqual("0.0.0.3/32", actual)
+
+
+class CloudProfileImageTest(unittest.TestCase):
+    def test_image_list(self):
+        self.maxDiff = None
+
+        sample_data = """
+        - id: firewall-ubuntu-2.0.20200714
+          name: Firewall 2 Ubuntu 20200714
+          description: Firewall 2 Ubuntu 20200714
+          url: http://images.metal-stack.io/metal-os/master/firewall/2.0-ubuntu/20200714/img.tar.lz4
+          features:
+            - firewall
+            - machine
+        - id: firewall-2.0.20200714
+          name: Firewall 2 Debian 20200714
+          description: Firewall 2 Debian 20200714
+          url: http://images.metal-stack.io/metal-os/master/firewall/2.0/20200714/img.tar.lz4
+          features:
+            - firewall
+        - id: ubuntu-19.10.20200331
+          name: Ubuntu 19.10 20200331
+          description: Ubuntu 19.10 20200331
+          url: http://images.metal-stack.io/metal-os/ubuntu/19.10/20200331/img.tar.lz4
+          features:
+            - machine
+        - id: ubuntu-19.10.20200701
+          name: Ubuntu 19.10 20200701
+          description: Ubuntu 19.10 20200701
+          url: http://images.metal-stack.io/metal-os/ubuntu/19.10/20200701/img.tar.lz4
+          features:
+            - machine
+        - id: ubuntu-20.04.20200331
+          name: Ubuntu 20.04 20200331
+          description: Ubuntu 20.04 20200331
+          url: http://images.metal-stack.io/metal-os/ubuntu/20.04/20200331/img.tar.lz4
+          features:
+            - machine
+        - id: debian-10.0.20200331
+          name: Debian 10.0.20200331
+          description: Debian 10 20200331
+          url: http://images.metal-stack.io/metal-os/debian/10/20200331/img.tar.lz4
+          features:
+            - machine
+        - id: centos-7.0.20210620
+          name: Centos 7 20210620
+          description: Centos 7 20210620
+          url: http://images.metal-stack.io/metal-os/master/centos/7/20210620/img.tar.lz4
+          omit_from_cloud_profile: yes
+          features:
+              - machine
+        """
+        actual = gardener.machine_images_for_cloud_profile(yaml.safe_load(sample_data))
+        expected = [
+            {
+                "name": "firewall-ubuntu",
+                "versions": [
+                    {"version": "2.0"},
+                    {"version": "2.0.20200714"},
+                ]
+            },
+            {
+                "name": "ubuntu",
+                "versions": [
+                    {"version": "19.10"},
+                    {"version": "19.10.20200331"},
+                    {"version": "19.10.20200701"},
+                    {"version": "20.04"},
+                    {"version": "20.04.20200331"},
+                ],
+            },
+            {
+                "name": "debian",
+                "versions": [
+                    {"version": "10.0"},
+                    {"version": "10.0.20200331"},
+                ],
+            },
+        ]
+
+        self.assertListEqual(actual, expected)
+
+    def test_image_list_with_cri_mapping(self):
+        self.maxDiff = None
+
+        sample_data = """
+        - id: firewall-ubuntu-2.0.20200714
+          name: Firewall 2 Ubuntu 20200714
+          description: Firewall 2 Ubuntu 20200714
+          url: http://images.metal-stack.io/metal-os/master/firewall/2.0-ubuntu/20200714/img.tar.lz4
+          features:
+            - firewall
+            - machine
+        - id: firewall-2.0.20200714
+          name: Firewall 2 Debian 20200714
+          description: Firewall 2 Debian 20200714
+          url: http://images.metal-stack.io/metal-os/master/firewall/2.0/20200714/img.tar.lz4
+          features:
+            - firewall
+        - id: ubuntu-19.10.20200331
+          name: Ubuntu 19.10 20200331
+          description: Ubuntu 19.10 20200331
+          url: http://images.metal-stack.io/metal-os/ubuntu/19.10/20200331/img.tar.lz4
+          features:
+            - machine
+        - id: ubuntu-19.10.20200701
+          name: Ubuntu 19.10 20200701
+          description: Ubuntu 19.10 20200701
+          url: http://images.metal-stack.io/metal-os/ubuntu/19.10/20200701/img.tar.lz4
+          features:
+            - machine
+        - id: ubuntu-20.04.20200331
+          name: Ubuntu 20.04 20200331
+          description: Ubuntu 20.04 20200331
+          url: http://images.metal-stack.io/metal-os/ubuntu/20.04/20200331/img.tar.lz4
+          features:
+            - machine
+        """
+
+        cris = [
+            {
+                "name": "containerd",
+                "containerRuntimes": [
+                    {"type": "gvisor"},
+                    {"type": "kata-containers"},
+                ],
+            }
+        ]
+        cri_mapping = {
+            "ubuntu": {
+                "when": {
+                    "operator": ">=",
+                    "version": "20.04",
+                },
+                "cris": cris,
+            }
+        }
+
+        actual = gardener.machine_images_for_cloud_profile(yaml.safe_load(sample_data), cris=cri_mapping)
+        expected = [
+            {
+                "name": "firewall-ubuntu",
+                "versions": [
+                    {"version": "2.0"},
+                    {"version": "2.0.20200714"},
+                ]
+            },
+            {
+                "name": "ubuntu",
+                "versions": [
+                    {"version": "19.10"},
+                    {"version": "19.10.20200331"},
+                    {"version": "19.10.20200701"},
+                    {
+                        "version": "20.04",
+                        "cri": [
+                            {
+                                "name": "containerd",
+                                "containerRuntimes": [
+                                    {"type": "gvisor"},
+                                    {"type": "kata-containers"},
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "version": "20.04.20200331",
+                        "cri": [
+                            {
+                                "name": "containerd",
+                                "containerRuntimes": [
+                                    {"type": "gvisor"},
+                                    {"type": "kata-containers"},
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ]
+
+        self.assertListEqual(actual, expected)
+
+
+    def test_image_list_with_compatibility_mapping(self):
+        self.maxDiff = None
+
+        sample_data = """
+        - id: debian-12.0.20240101
+          name: Debian 12 20240101
+          description: Debian 12 20240101
+          url: http://images.metal-stack.io/metal-os/debian/12/img.tar.lz4
+          features:
+            - machine
+        - id: debian-12.0.20250231
+          name: Debian 12 20250231
+          description: Debian 12 20250231
+          url: http://images.metal-stack.io/metal-os/debian/12/img.tar.lz4
+          features:
+            - machine
+        """
+
+        compat_mapping = {
+            "debian": {
+                "when": {
+                    "operator": "<",
+                    "version": "12.0.20250101",
+                    "except": ["12.0"],
+                },
+                "kubelet": "<= 1.30",
+            }
+        }
+
+        actual = gardener.machine_images_for_cloud_profile(yaml.safe_load(sample_data), compatibilities=compat_mapping)
+        expected = [
+            {
+                "name": "debian",
+                "versions": [
+                    {
+                        "version": "12.0",
+                    },
+                    {
+                        "version": "12.0.20240101",
+                        "kubeletVersionConstraint": "<= 1.30"
+                    },
+                    {
+                        "version": "12.0.20250231",
+                    },
+                ],
+            },
+        ]
+
+        self.assertListEqual(actual, expected)

--- a/test/mock/gke_container_subnets.json
+++ b/test/mock/gke_container_subnets.json
@@ -1,0 +1,44 @@
+[
+  {
+    "ipCidrRange": "0.0.0.1/32",
+    "network": "projects/test-project/global/networks/default",
+    "subnetwork": "projects/test-project/regions/us-west1/subnetworks/default"
+  },
+  {
+    "ipCidrRange": "0.0.0.2/32",
+    "network": "projects/test-project/global/networks/default",
+    "subnetwork": "projects/test-project/regions/southamerica-east1/subnetworks/default"
+  },
+  {
+    "ipCidrRange": "0.0.0.3/32",
+    "network": "projects/test-project/global/networks/default",
+    "secondaryIpRanges": [
+      {
+        "ipCidrRange": "0.0.0.4/32",
+        "rangeName": "prod-cluster-pods-a",
+        "status": "IN_USE_MANAGED_POD"
+      },
+      {
+        "ipCidrRange": "0.0.0.5/32",
+        "rangeName": "prod-cluster-services-a",
+        "status": "IN_USE_SERVICE"
+      },
+      {
+        "ipCidrRange": "0.0.0.6/32",
+        "rangeName": "test-cluster-pods-b",
+        "status": "IN_USE_MANAGED_POD"
+      },
+      {
+        "ipCidrRange": "0.0.0.7/32",
+        "rangeName": "test-cluster-services-b",
+        "status": "IN_USE_SERVICE"
+      }
+    ],
+    "subnetwork": "projects/test-project/regions/europe-west3/subnetworks/default"
+  },
+  {
+    "ipCidrRange": "0.0.0.8/32",
+    "network": "projects/test-project/global/networks/default",
+    "subnetwork": "projects/test-project/regions/asia-northeast2/subnetworks/default"
+  }
+]


### PR DESCRIPTION
## Description

The tests in this repo were not executed, so this PR additionally fixes this issue.

For the Gardener Operator roles as provided by https://github.com/metal-stack/metal-roles/pull/422, this pull request provides the modules used by these roles.

The new modules are:

- `virtual_garden_kubeconfig`: Provides an access kubeconfig for the virtual garden as created by the Gardener Operator deployment (action_plugin)
- `discovery_api_k8s`: Allows inspecting api-resources present in the Kubernetes API (like `kubectl api-resources`)
- `patch_service_status_k8s`: Allows patching the status of a `Service` resource (required for Gardener's Istio Ingress wait condition in local environments, this mimics the mutating webhook from their provider-local, moved from mini-lab)

New filter plugins are:

- `machine_images_for_cloud_profile`: Transforms machine images as defined for the metal-api deployment for the Gardener cloud profile and GEPM parametrization (moved from metal-roles)
- `extract_gcp_node_network`: Extracts the node network of a gcloud network response (used at multiple places to figure out network CIDRs for Gardener runtime clusters, moved from metal-roles)

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
