### PR TITLE
Template module variables in action plugin.

### DIFF
--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -59,6 +59,11 @@ class ActionModule(ActionBase):
             result["msg"] = str(validation_result.error_messages)
             return result
 
+        # as we can pick up the module inputs from task_vars,
+        # we have to run this through the templar to allow using
+        # variables in the module inputs
+        task_args = self._templar.template(task_args)
+
         self._supports_check_mode = True
 
         if task_args.get('cache') and os.path.isfile(self._cache_file_path()):
@@ -167,7 +172,7 @@ class RemoteResolver():
 
         task_args = task_args.copy()
 
-        self._url = module._templar.template(task_args.pop("url", None))
+        self._url = task_args.pop("url", None)
         if not self._url:
             raise ValueError("url is required")
 

--- a/test/integration/group_vars/all/release_vector.yaml
+++ b/test/integration/group_vars/all/release_vector.yaml
@@ -1,6 +1,8 @@
 ---
+metal_stack_release_version: simple
+
 metal_stack_release_vectors:
-  - url: oci://localhost:5000/releases:simple
+  - url: oci://localhost:5000/releases:{{ metal_stack_release_version }}
     variable_mapping_path: test_release.mapping
     include_role_defaults: ansible-test/roles/defaults
     oci_registry_scheme: http


### PR DESCRIPTION
## Description

This allows to use variables for all parameters of the module even when used through the magic variable `metal_stack_release_vectors`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
