### PR TITLE
Allow login with cosign.

### DIFF
--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -472,7 +472,7 @@ class OciLoader():
 
         try:
             if self._username and self._password:
-                subprocess.run(args=[bin_path, "login", "--username",  self._username, "--password-stdin=true"],
+                subprocess.run(args=[bin_path, "login", self._registry, "--username",  self._username, "--password-stdin=true"],
                                input=self._password.encode(), check=True, capture_output=True)
 
             if self._cosign_key:

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -428,8 +428,9 @@ class OciLoader():
         self._dest_filter = kwargs.pop("dest_filter", None)
         self._media_type = kwargs.pop(
             "media_type", OciLoader.RELEASE_VECTOR_MEDIA_TYPE)
+        self._registry_scheme = kwargs.pop("oci_registry_scheme", "https")
         self._registry, self._namespace, self._version = self._parse_oci_ref(
-            self._url, scheme=kwargs.pop("oci_registry_scheme", "https"))
+            self._url, scheme=self._registry_scheme)
         self._username = kwargs.pop("oci_registry_username", None)
         self._password = kwargs.pop("oci_registry_password", None)
 
@@ -497,7 +498,7 @@ class OciLoader():
             opts.append(WithUsernamePassword(
                 username=self._username, password=self._password))
 
-        client = NewClient(self._registry,
+        client = NewClient("%s://%s" % (self._registry_scheme, self._registry),
                            *opts
                            )
 
@@ -550,7 +551,7 @@ class OciLoader():
         if tag is None:
             raise ValueError("oci ref %s needs to specify a tag" % full_ref)
         url = urlparse("%s://%s" % (scheme, ref))
-        return "%s://%s" % (scheme, url.netloc), url.path.removeprefix('/'), tag
+        return url.netloc, url.path.removeprefix('/'), tag
 
     @staticmethod
     def _extract_tar_gzip_file(bytes, member):

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from yaml import safe_load
 from urllib.parse import urlparse
 from traceback import format_exc
+from dataclasses import dataclass
 
 from ansible.module_utils.urls import open_url
 from ansible.plugins.action import ActionBase
@@ -125,8 +126,11 @@ class ActionModule(ActionBase):
                 old=dict(type='str', required=True),
                 new=dict(type='str', required=True),
             )),
-            oci_registry_username=dict(type='str', required=False),
-            oci_registry_password=dict(type='str', required=False),
+            oci_registry_credentials=dict(type='list', elements='dict', required=False, default=list(), options=dict(
+                name=dict(type='str', required=True),
+                username=dict(type='str', required=True),
+                password=dict(type='str', required=True),
+            )),
             oci_registry_scheme=dict(
                 type='str', required=False, default='https'),
             oci_cosign_verify_certificate_identity=dict(
@@ -190,10 +194,8 @@ class RemoteResolver():
             'ansible_roles_path', "ansible-roles")
 
         self._loader_args = dict(
-            oci_registry_username=task_args.pop(
-                "oci_registry_username", None),
-            oci_registry_password=task_args.pop(
-                "oci_registry_password", None),
+            oci_registry_credentials=task_args.pop(
+                "oci_registry_credentials", None),
             oci_registry_scheme=task_args.pop(
                 "oci_registry_scheme", 'https'),
             oci_cosign_verify_certificate_identity=task_args.pop(
@@ -431,8 +433,13 @@ class OciLoader():
         self._registry_scheme = kwargs.pop("oci_registry_scheme", "https")
         self._registry, self._namespace, self._version = self._parse_oci_ref(
             self._url, scheme=self._registry_scheme)
-        self._username = kwargs.pop("oci_registry_username", None)
-        self._password = kwargs.pop("oci_registry_password", None)
+
+        self._registry_credentials = dict[str, RegistryCredential]()
+        for credentials in kwargs.pop("oci_registry_credentials", list()):
+            self._registry_credentials[credentials.get("name")] = RegistryCredential(
+                user=credentials.get("username"),
+                password=credentials.get("password")
+            )
 
         self._cosign_identity = kwargs.pop(
             "oci_cosign_verify_certificate_identity", None)
@@ -472,21 +479,25 @@ class OciLoader():
                                     to_native(e.message)) from e
 
         try:
-            if self._username and self._password:
-                subprocess.run(args=[bin_path, "login", self._registry, "--username",  self._username, "--password-stdin=true"],
-                               input=self._password.encode(), check=True, capture_output=True)
+            env = dict()
+            args = [bin_path, "verify"]
+
+            if self._registry_credentials.get(self._registry, None):
+                creds = self._registry_credentials.get(self._registry)
+                args += ["--registry-username", creds.user]
+                env["COSIGN_REGISTRY_PASSWORD"] = creds.password
 
             if self._cosign_key:
-                subprocess.run(args=[bin_path, "verify", "--key", "env://PUBKEY", self._url],
-                               env=dict(PUBKEY=self._cosign_key), check=True, capture_output=True)
-                display.display(
-                    "- %s was verified successfully by public key through cosign" % self._url, color=C.COLOR_OK)
+                args += ["--key", "env://PUBKEY", self._url]
+                env["PUBKEY"] = self._cosign_key
+
             elif self._cosign_identity or self._cosign_issuer:
-                subprocess.run(args=[bin_path, "verify", "--certificate-oidc-issuer", self._cosign_issuer,
-                                     "--certificate-identity", self._cosign_identity, self._url],
-                               check=True, capture_output=True)
-                display.display(
-                    "- %s was verified successfully by oidc-issuer through cosign" % self._url, color=C.COLOR_OK)
+                args += ["--certificate-oidc-issuer", self._cosign_issuer,
+                         "--certificate-identity", self._cosign_identity, self._url]
+
+            subprocess.run(args=args, env=env, check=True, capture_output=True)
+            display.display(
+                "- %s was verified successfully by oidc-issuer through cosign" % self._url, color=C.COLOR_OK)
 
         except subprocess.CalledProcessError as e:
             raise RuntimeError("cosign verification returned with exit code %s: %s" % (
@@ -494,9 +505,11 @@ class OciLoader():
 
     def _download_blob(self):
         opts = [WithDefaultName(self._namespace)]
-        if self._username and self._password:
+
+        if self._registry_credentials.get(self._registry, None):
+            creds = self._registry_credentials.get(self._registry)
             opts.append(WithUsernamePassword(
-                username=self._username, password=self._password))
+                username=creds.user, password=creds.password))
 
         client = NewClient("%s://%s" % (self._registry_scheme, self._registry),
                            *opts
@@ -581,3 +594,9 @@ class OciLoader():
             member.name = os.path.join(base, *parts[1:])
             return member
         return filter
+
+
+@dataclass
+class RegistryCredential:
+    user: str
+    password: str

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -195,7 +195,7 @@ class RemoteResolver():
 
         self._loader_args = dict(
             oci_registry_credentials=task_args.pop(
-                "oci_registry_credentials", None),
+                "oci_registry_credentials", list()),
             oci_registry_scheme=task_args.pop(
                 "oci_registry_scheme", 'https'),
             oci_cosign_verify_certificate_identity=task_args.pop(
@@ -467,7 +467,7 @@ class OciLoader():
         else:
             return self._extract_tar_gzip_file(blob, member=self._member)
 
-    def _cosign_validate(self):
+    def _cosign_validate(self) -> None:
         if not self._cosign_key and not (self._cosign_identity and self._cosign_issuer):
             return
 
@@ -478,30 +478,30 @@ class OciLoader():
             raise FileNotFoundError("cosign needs to be installed: %s" %
                                     to_native(e.message)) from e
 
+        env = dict()
+        args = [bin_path, "verify"]
+
+        if self._registry_credentials.get(self._registry, None):
+            creds = self._registry_credentials.get(self._registry)
+            args += ["--registry-username", creds.user]
+            env["COSIGN_REGISTRY_PASSWORD"] = creds.password
+
+        if self._cosign_key:
+            args += ["--key", "env://PUBKEY", self._url]
+            env["PUBKEY"] = self._cosign_key
+
+        elif self._cosign_identity or self._cosign_issuer:
+            args += ["--certificate-oidc-issuer", self._cosign_issuer,
+                     "--certificate-identity", self._cosign_identity, self._url]
+
         try:
-            env = dict()
-            args = [bin_path, "verify"]
-
-            if self._registry_credentials.get(self._registry, None):
-                creds = self._registry_credentials.get(self._registry)
-                args += ["--registry-username", creds.user]
-                env["COSIGN_REGISTRY_PASSWORD"] = creds.password
-
-            if self._cosign_key:
-                args += ["--key", "env://PUBKEY", self._url]
-                env["PUBKEY"] = self._cosign_key
-
-            elif self._cosign_identity or self._cosign_issuer:
-                args += ["--certificate-oidc-issuer", self._cosign_issuer,
-                         "--certificate-identity", self._cosign_identity, self._url]
-
             subprocess.run(args=args, env=env, check=True, capture_output=True)
-            display.display(
-                "- %s was verified successfully by oidc-issuer through cosign" % self._url, color=C.COLOR_OK)
-
         except subprocess.CalledProcessError as e:
             raise RuntimeError("cosign verification returned with exit code %s: %s" % (
                 e.returncode, to_native(e.stderr))) from e
+
+        display.display(
+            "- %s was verified successfully through cosign" % self._url, color=C.COLOR_OK)
 
     def _download_blob(self):
         opts = [WithDefaultName(self._namespace)]

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -473,7 +473,7 @@ class OciLoader():
         try:
             if self._username and self._password:
                 subprocess.run(args=[bin_path, "login", "--username",  self._username, "--password-stdin=true"],
-                               input=self._password, check=True, capture_output=True)
+                               input=self._password.encode(), check=True, capture_output=True)
 
             if self._cosign_key:
                 subprocess.run(args=[bin_path, "verify", "--key", "env://PUBKEY", self._url],

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -448,32 +448,7 @@ class OciLoader():
             raise ImportError(
                 "opencontainers must be installed in order to resolve metal-stack oci release vectors")
 
-        if self._cosign_key or self._cosign_identity or self._cosign_issuer:
-            try:
-                bin_path = process.get_bin_path(
-                    "cosign", required=True, opt_dirs=None)
-
-                if self._username and self._password:
-                    subprocess.run(args=[bin_path, "login", "--username",  self._username, "--password-stdin=true"],
-                                   input=self._password, check=True, capture_output=True)
-
-                if self._cosign_key:
-                    subprocess.run(args=[bin_path, "verify", "--key", "env://PUBKEY", self._url],
-                                   env=dict(PUBKEY=self._cosign_key), check=True, capture_output=True)
-                    display.display(
-                        "- %s was verified successfully by public key through cosign" % self._url, color=C.COLOR_OK)
-                elif self._cosign_identity or self._cosign_issuer:
-                    subprocess.run(args=[bin_path, "verify", "--certificate-oidc-issuer", self._cosign_issuer,
-                                         "--certificate-identity", self._cosign_identity, self._url],
-                                   check=True, capture_output=True)
-                    display.display(
-                        "- %s was verified successfully by oidc-issuer through cosign" % self._url, color=C.COLOR_OK)
-            except ValueError as e:
-                raise FileNotFoundError("cosign needs to be installed: %s" %
-                                        to_native(e.message)) from e
-            except subprocess.CalledProcessError as e:
-                raise RuntimeError("cosign verification returned with exit code %s: %s" % (
-                    e.returncode, to_native(e.stderr))) from e
+        self._cosign_validate()
 
         blob = self._download_blob()
 
@@ -483,6 +458,38 @@ class OciLoader():
             return self._extract_tar_gzip(blob, dest=self._dest, filter=self._dest_filter)
         else:
             return self._extract_tar_gzip_file(blob, member=self._member)
+
+    def _cosign_validate(self):
+        if not self._cosign_key and not (self._cosign_identity and self._cosign_issuer):
+            return
+
+        try:
+            bin_path = process.get_bin_path(
+                "cosign", required=True, opt_dirs=None)
+        except ValueError as e:
+            raise FileNotFoundError("cosign needs to be installed: %s" %
+                                    to_native(e.message)) from e
+
+        try:
+            if self._username and self._password:
+                subprocess.run(args=[bin_path, "login", "--username",  self._username, "--password-stdin=true"],
+                               input=self._password, check=True, capture_output=True)
+
+            if self._cosign_key:
+                subprocess.run(args=[bin_path, "verify", "--key", "env://PUBKEY", self._url],
+                               env=dict(PUBKEY=self._cosign_key), check=True, capture_output=True)
+                display.display(
+                    "- %s was verified successfully by public key through cosign" % self._url, color=C.COLOR_OK)
+            elif self._cosign_identity or self._cosign_issuer:
+                subprocess.run(args=[bin_path, "verify", "--certificate-oidc-issuer", self._cosign_issuer,
+                                     "--certificate-identity", self._cosign_identity, self._url],
+                               check=True, capture_output=True)
+                display.display(
+                    "- %s was verified successfully by oidc-issuer through cosign" % self._url, color=C.COLOR_OK)
+
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("cosign verification returned with exit code %s: %s" % (
+                e.returncode, to_native(e.stderr))) from e
 
     def _download_blob(self):
         opts = [WithDefaultName(self._namespace)]

--- a/library/metal_stack_release_vector.py
+++ b/library/metal_stack_release_vector.py
@@ -119,17 +119,28 @@ options:
                             - The value to replace the value specified by the old option with.
                         required: true
                         type: str
-            oci_registry_username:
+            oci_registry_credentials:
                 description:
-                    - The username to authenticate against the OCI registry.
+                    - Provides OCI registry credentials for different registries.
                 required: false
-                type: str
-            oci_registry_password:
-                description:
-                description:
-                    - The password to authenticate against the OCI registry.
-                required: false
-                type: str
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description:
+                            - The name of the registry.
+                        required: true
+                        type: str
+                    username:
+                        description:
+                            - The username to authenticate against the OCI registry.
+                        required: true
+                        type: str
+                    password:
+                        description:
+                            - The password to authenticate against the OCI registry.
+                        required: true
+                        type: str
             oci_registry_scheme:
                 description:
                     - The scheme to communicate with the OCI registry.


### PR DESCRIPTION
## Description

Currently, when using signature validation that require registry credentials for the image, cosign fails with `UNAUTHORIZED: authentication required`.

### Breaking Change

```BREAKING_CHANGE
The `metal_stack_release_vector` module now uses `oci_registry_credentials` to provide registry credentials instead of `oci_registry_username` and `oci_registry_password`. This way, it is possible to pass credentials for multiple registries.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
