### PR TITLE
add helm_debug to helm-chart role

### DIFF
--- a/roles/helm-chart/README.md
+++ b/roles/helm-chart/README.md
@@ -16,12 +16,13 @@ Installs a helm chart.
 | helm_chart_version            |           | The version of the chart                                                                               |
 | helm_value_file_template      |           | The path to a helm value file (e.g. from the role's templates folder)                                  |
 | helm_config_params            |           | Values to pass to helm via the `--set` option                                                          |
-| helm_kubeconfig               |           | Adds the `--kubeconfig` option to point helm to another than the default kubeconfig path               | 
+| helm_kubeconfig               |           | Adds the `--kubeconfig` option to point helm to another than the default kubeconfig path               |
 | helm_force                    |           | Adds the `--force` option                                                                              |
+| helm_debug                    |           | Adds the `--debug` option                                                                              |
 | helm_repo                     |           | Adds the chart repository URL                                                                          |
 | helm_wait                     |           | Adds the `--wait` option                                                                               |
 | helm_timeout                  |           | Waits the given period of time before giving up when used in conjunction with `--wait`                 |
-| helm_skip_crds                |           | Skips the CRD installation step                                                                        | 
+| helm_skip_crds                |           | Skips the CRD installation step                                                                        |
 | helm_bin                      |           | Alternative path to the helm binary                                                                    |
 | helm_chart_remote_temp        |           | The path on the target host where the values file is templated to                                      |
 | helm_chart_custom_folder      |           | The path to a local helm chart                                                                         |

--- a/roles/helm-chart/README.md
+++ b/roles/helm-chart/README.md
@@ -19,6 +19,7 @@ Installs a helm chart.
 | helm_kubeconfig               |           | Adds the `--kubeconfig` option to point helm to another than the default kubeconfig path               |
 | helm_force                    |           | Adds the `--force` option                                                                              |
 | helm_debug                    |           | Adds the `--debug` option                                                                              |
+| helm_dryrun                   |           | Adds the `--debug` and `--dry-run` options                                                             |
 | helm_repo                     |           | Adds the chart repository URL                                                                          |
 | helm_wait                     |           | Adds the `--wait` option                                                                               |
 | helm_timeout                  |           | Waits the given period of time before giving up when used in conjunction with `--wait`                 |

--- a/roles/helm-chart/defaults/main.yaml
+++ b/roles/helm-chart/defaults/main.yaml
@@ -6,3 +6,4 @@ helm_chart_remote_temp: /tmp/helm-chart
 helm_chart_inject_config_hash: false
 helm_wait: true
 helm_force: false
+helm_debug: false

--- a/roles/helm-chart/defaults/main.yaml
+++ b/roles/helm-chart/defaults/main.yaml
@@ -7,3 +7,4 @@ helm_chart_inject_config_hash: false
 helm_wait: true
 helm_force: false
 helm_debug: false
+helm_dryrun: false

--- a/roles/helm-chart/tasks/main.yaml
+++ b/roles/helm-chart/tasks/main.yaml
@@ -37,6 +37,7 @@
     --namespace {{ helm_target_namespace }}
     {% if helm_kubeconfig is defined %}--kubeconfig {{ helm_kubeconfig }}{% endif %}
     {% if helm_force is defined and helm_force %}--force{% endif %}
+    {% if helm_dryrun is defined and helm_dryrun %}--debug --dry-run{% endif %}
     {% if helm_debug is defined and helm_debug %}--debug{% endif %}
     {% if helm_additional_params is defined and helm_additional_params %}{{ helm_additional_params | join(' ') if helm_additional_params is iterable else helm_additional_params }}{% endif %}
     {% if _helm_chart_combined_params %}--set '{% for k, v in _helm_chart_combined_params.items() %}{{ k }}={{ v }}{% if not loop.last %},{% endif %}{% endfor %}'{% endif %}

--- a/roles/helm-chart/tasks/main.yaml
+++ b/roles/helm-chart/tasks/main.yaml
@@ -37,6 +37,7 @@
     --namespace {{ helm_target_namespace }}
     {% if helm_kubeconfig is defined %}--kubeconfig {{ helm_kubeconfig }}{% endif %}
     {% if helm_force is defined and helm_force %}--force{% endif %}
+    {% if helm_debug is defined and helm_debug %}--debug{% endif %}
     {% if helm_additional_params is defined and helm_additional_params %}{{ helm_additional_params | join(' ') if helm_additional_params is iterable else helm_additional_params }}{% endif %}
     {% if _helm_chart_combined_params %}--set '{% for k, v in _helm_chart_combined_params.items() %}{{ k }}={{ v }}{% if not loop.last %},{% endif %}{% endfor %}'{% endif %}
     {% if helm_value_file_template is defined and helm_value_file_template %}-f {{ helm_value_file_template | basename }}{% endif %}


### PR DESCRIPTION
## Description

This PR adds the posibility to enable helm debugging using the new variable `helm_debug` which adds the flag `--debug` to the helm command, when enabled.