### PR TITLE
Add test and filter plugin for easier list handling

### DIFF
--- a/filter_plugins/common.py
+++ b/filter_plugins/common.py
@@ -42,12 +42,14 @@ def transpile_ignition_config(ignition_config):
     except ValueError as e:
         raise AnsibleFilterError("ct needs to be installed: %s" % e.message)
 
-    process = subprocess.Popen(["ct"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(
+        ["ct"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
     out, err = process.communicate(input=_encode(ignition_config))
     return_code = process.returncode
 
     if return_code != 0:
-        raise AnsibleFilterError("transpilation failed with return code %d: %s (%s)" % (return_code, out, err))
+        raise AnsibleFilterError(
+            "transpilation failed with return code %d: %s (%s)" % (return_code, out, err))
 
     return _decode(out.strip())
 
@@ -85,7 +87,8 @@ def _extract_peer_address(host, k8s_nodes):
             net = ipaddress.ip_network(cidr)
             gen = net.hosts()
             return str(next(gen))
-    raise AnsibleFilterError("could not find host in k8s nodes and determine peer address: %s", host)
+    raise AnsibleFilterError(
+        "could not find host in k8s nodes and determine peer address: %s", host)
 
 
 def metal_lb_conf(hostnames, hostvars, cidrs, k8s_nodes):
@@ -103,13 +106,16 @@ def metal_lb_conf(hostnames, hostvars, cidrs, k8s_nodes):
 
         asn = _extract_asn(host_vars['metal_tags'])
         if not asn:
-            raise AnsibleFilterError("host has no asn specified in its metal_tags: %s", host)
+            raise AnsibleFilterError(
+                "host has no asn specified in its metal_tags: %s", host)
 
         p = dict()
-        p['peer-address'] = _extract_peer_address(host_vars['metal_hostname'], k8s_nodes)
+        p['peer-address'] = _extract_peer_address(
+            host_vars['metal_hostname'], k8s_nodes)
         p['peer-asn'] = int(asn)
         p['my-asn'] = int(asn)
-        p['node-selectors'] = _generate_node_selectors(host_vars['metal_hostname'])
+        p['node-selectors'] = _generate_node_selectors(
+            host_vars['metal_hostname'])
         peers.append(p)
 
     address_pool = dict()
@@ -124,6 +130,12 @@ def metal_lb_conf(hostnames, hostvars, cidrs, k8s_nodes):
     }
 
 
+def list_wrap(value, no_wrap_if_already_list=True):
+    if no_wrap_if_already_list and isinstance(value, list):
+        return value
+    return [value]
+
+
 class FilterModule(object):
     '''Common cloud-native filter plugins'''
 
@@ -132,4 +144,5 @@ class FilterModule(object):
             'humanfriendly': parse_size,
             'transpile_ignition_config': transpile_ignition_config,
             'metal_lb_conf': metal_lb_conf,
+            'list_wrap': list_wrap,
         }

--- a/test_plugins/common.py
+++ b/test_plugins/common.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def is_list(value):
+    return isinstance(value, list)
+
+
+class TestModule(object):
+    def tests(self):
+        return {
+            'is_list': is_list,
+        }


### PR DESCRIPTION
## Description

In some places, particularly for the `k8s` lookup module (https://github.com/metal-stack/metal-roles/pull/484#discussion_r2459044739), a module returns either a dict or a list depending on the amount of results.

There seems to be no easy, intuitive way to check if a variable is a list with Jinja (needs to check that it's iterable, but not string and not a mapping).

The pattern with the filter and test plugin would then look like this:

```yaml
    - name: Get pod name
      set_fact:
        _pod: "{{ (lookup('k8s', api_version='v1', kind='Pod', label_selector='app=some-pod') | list_wrap)[0].get('metadata', {}).get('name') }}"

# alternatively:
    - name: Get pods
      set_fact:
        _pods: "{{ (lookup('k8s', api_version='v1', kind='Pod', label_selector='app=some-pod') }}"

    - name: Get pod name
      set_fact:
        _pod: "{{ (_pods if _pods is is_list else [_pods])[0].get('metadata', {}).get('name') }}"
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
