### PR TITLE
feat(systemd-docker-service): allow optional `--security-opt` parameters

### DIFF
--- a/roles/systemd-docker-service/README.md
+++ b/roles/systemd-docker-service/README.md
@@ -24,6 +24,7 @@ Renders a systemd unit file that runs an application within a docker container.
 | systemd_docker_log_driver         |           | The log driver to use for the container instead of the system default                 |
 | systemd_docker_log_opt_max_file   |           | The maximum amount of log files if applicable                                         |
 | systemd_docker_log_opt_max_size   |           | The maximum log file size if applicable                                               |
+| systemd_docker_security_opts      |           | Adds --security-opt to the container                                                  |
 | systemd_service_restart_sec       |           | The number of seconds to wait before restarting the systemd service                   |
 | systemd_service_timeout_start_sec |           | The number of seconds to wait before starting the systemd service                     |
 | systemd_service_timeout_stop_sec  |           | The number of seconds to wait for the systemd service to stop                         |

--- a/roles/systemd-docker-service/defaults/main.yml
+++ b/roles/systemd-docker-service/defaults/main.yml
@@ -9,6 +9,7 @@ systemd_docker_volumes: []
 systemd_docker_cap_add: []
 systemd_docker_ports: []
 systemd_docker_host_to_ip_mapping: []
+systemd_docker_security_opts: []
 systemd_service_restart_sec: 10
 systemd_service_timeout_start_sec: 10
 systemd_service_timeout_stop_sec: 10

--- a/roles/systemd-docker-service/templates/service.j2
+++ b/roles/systemd-docker-service/templates/service.j2
@@ -43,6 +43,9 @@ ExecStart=/usr/bin/docker run --name=%n \
     --log-opt max-file={{ systemd_docker_log_opt_max_file }} \
     --log-opt max-size={{ systemd_docker_log_opt_max_size }} \
 {% endif %}
+{% for secopt in systemd_docker_security_opts %}
+    --security-opt {{ secopt }} \
+{% endfor %}
 {% if systemd_docker_network %}
     --network {{ systemd_docker_network }} \
 {% endif %}

--- a/test/integration/playbook.yaml
+++ b/test/integration/playbook.yaml
@@ -59,8 +59,9 @@
           - url: oci://ghcr.io/metal-stack/releases:develop
             variable_mapping_path: metal_stack_release.mapping
             include_role_defaults: metal-roles/common/roles/defaults
-            oci_cosign_verify_key: |
-              -----BEGIN PUBLIC KEY-----
-              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdeAXd2namgVNDT0APmogKGwaV+Q4
-              rfe4uVgmsyBbb6TrhX5Py6x1PsonDahTvdVpbSGC7QGEjxIHdi8HnJ4Okg==
-              -----END PUBLIC KEY-----
+            # FIXME, see: https://github.com/metal-stack/ansible-common/issues/49
+            # oci_cosign_verify_key: |
+            #   -----BEGIN PUBLIC KEY-----
+            #   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdeAXd2namgVNDT0APmogKGwaV+Q4
+            #   rfe4uVgmsyBbb6TrhX5Py6x1PsonDahTvdVpbSGC7QGEjxIHdi8HnJ4Okg==
+            #   -----END PUBLIC KEY-----


### PR DESCRIPTION
## Description

Deploying alloy on older switches throws "pthread_create failed: Operation not permitted".
https://docs.docker.com/engine/security/seccomp/#run-without-the-default-seccomp-profile helps in this case, but needs to be used carefully. 


<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
