### PR TITLE
add existing env for proxy support, if set

### DIFF
--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -479,6 +479,7 @@ class OciLoader():
                                     to_native(e.message)) from e
 
         env = os.environ.copy()
+        print(env)
         args = [bin_path, "verify"]
 
         if self._registry_credentials.get(self._registry, None):

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -478,7 +478,7 @@ class OciLoader():
             raise FileNotFoundError("cosign needs to be installed: %s" %
                                     to_native(e.message)) from e
 
-        env = dict()
+        env = os.environ.copy()
         args = [bin_path, "verify"]
 
         if self._registry_credentials.get(self._registry, None):

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -479,7 +479,8 @@ class OciLoader():
                                     to_native(e.message)) from e
 
         env = os.environ.copy()
-        print(env)
+        display.display ("current env: %s" % env, color=C.COLOR_OK)
+        
         args = [bin_path, "verify"]
 
         if self._registry_credentials.get(self._registry, None):

--- a/action_plugins/metal_stack_release_vector.py
+++ b/action_plugins/metal_stack_release_vector.py
@@ -479,7 +479,6 @@ class OciLoader():
                                     to_native(e.message)) from e
 
         env = os.environ.copy()
-        display.display ("current env: %s" % env, color=C.COLOR_OK)
         
         args = [bin_path, "verify"]
 


### PR DESCRIPTION
## Description

Copy OS env into the env being used by cosign verify to enable proxy support in gitlab deployments.

## Release Notes

```NOTEWORTHY
Add environment variables support to cosign verify.
```